### PR TITLE
Fix JS namespace typo

### DIFF
--- a/assets/appstle-init.js
+++ b/assets/appstle-init.js
@@ -20,7 +20,7 @@
       appstleLoadScript("https://cdn.shopify.com/s/files/1/0660/5445/5602/t/13/assets/appstle-subscription.js?v=1683750752");
 
 
-      window.RS = Window.RS || {};
+      window.RS = window.RS || {};
       RS.Config = {
         "selectors": {
             "payment_button_selectors": "form[action$='/cart/add'] .shopify-payment-button",


### PR DESCRIPTION
## Summary
- fix wrong `Window` namespace reference in `appstle-init.js`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6844a542b98c8322acedb116655ef179