### PR TITLE
Update README with Shopify theme info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# MANEOK Shopify Theme
+
+This repository contains a Shopify theme used for the MANEOK storefront. The theme's templates are written using Shopify's Liquid language. Liquid files rely on Shopify's environment for rendering and cannot be viewed as plain HTML in a browser.
+
+## Preview the theme locally
+
+1. Install the [Shopify CLI](https://shopify.dev/apps/tools/cli).
+2. Authenticate with your store via `shopify login`.
+3. Run the following command from the repository root:
+
+```bash
+shopify theme serve
+```
+
+The CLI uploads the theme to your store and provides a local URL to preview it.
+
 ## Hi there 👋
 
 <!--


### PR DESCRIPTION
## Summary
- describe that MANEOK is a Shopify theme
- note that Liquid templates need Shopify to render and can't open directly in a browser
- add steps to preview using `shopify theme serve`

## Testing
- `npm test` *(fails: could not find package.json)*
- `make test` *(fails: no such file or target)*

------
https://chatgpt.com/codex/tasks/task_e_6844a6cf81588322874d9d9a724bd591