### PR TITLE
Fix tooltip property name

### DIFF
--- a/assets/appstle-init.js
+++ b/assets/appstle-init.js
@@ -49,7 +49,7 @@
         "subscriptionPriceDisplayText": "",
         "tooltipTitle": "Subscription detail",
         "showTooltipOnClick": "false",
-        "tooltipDesctiption": "<strong>Have complete control of your subscriptions<\/strong><br\/><br\/>Skip, reschedule, edit, or cancel deliveries anytime, based on your needs.",
+        "tooltipDescription": "<strong>Have complete control of your subscriptions<\/strong><br\/><br\/>Skip, reschedule, edit, or cancel deliveries anytime, based on your needs.",
         "tooltipDescriptionOnPrepaidPlan": "<b>Prepaid Plan Details<\/b><\/br> Total price: {{totalPrice}} ( Price for every delivery: {{pricePerDelivery}})",
         "tooltipDescriptionOnMultipleDiscount": "<b>Discount Details<\/b><\/br> Initial discount is {{discountOne}} and then {{discountTwo}}",
         "tooltipDescriptionCustomization": "{{{defaultTooltipDescription}}} <\/br>  {{{prepaidDetails}}} <\/br> {{{discountDetails}}}",


### PR DESCRIPTION
## Summary
- correct typo in `appstle-init.js` configuration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844a6e27ec88322a3c4002501bf01e8