### PR TITLE
Add Jest test for updateHistoryState

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "maneok",
+  "version": "1.0.0",
+  "description": "<!-- **Maneok/MANEOK** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+
+function getUpdateHistoryState() {
+  const content = fs.readFileSync(require('path').join(__dirname, '../assets/theme.js'), 'utf8');
+  const match = content.match(/_updateHistoryState: function\(variant\) {([\s\S]*?)\n\s*},/);
+  if (!match) throw new Error('Function not found');
+  return new Function('variant', match[1]);
+}
+
+test('_updateHistoryState updates window.history with variant id', () => {
+  const updateHistoryState = getUpdateHistoryState();
+  const replaceState = jest.fn();
+  global.history = { replaceState };
+  global.window = {
+    location: { protocol: 'https:', host: 'example.com', pathname: '/product' },
+    history: { replaceState }
+  };
+
+  updateHistoryState({ id: 42 });
+
+  expect(replaceState).toHaveBeenCalledWith(
+    { path: 'https://example.com/product?variant=42' },
+    '',
+    'https://example.com/product?variant=42'
+  );
+});


### PR DESCRIPTION
## Summary
- add Jest config in package.json
- ignore node_modules
- test `_updateHistoryState` in theme.js under tests/

## Testing
- `npm install --save-dev jest` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844a6e63dc8832283baea19217c6ca6