### PR TITLE
Add Shopify theme .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Temporary files and OS-specific artifacts
+.DS_Store
+Thumbs.db
+
+# Logs and runtime files
+*.log
+*.tmp
+*.temp
+*.bak
+*.swp
+
+# Node modules and build artifacts
+node_modules/
+.sass-cache/
+dist/
+build/
+
+# Local Shopify configuration
+config.yml
+config/settings_data.json
+
+# Source maps
+*.map
+
+# Shopify CLI cache
+.shopify/


### PR DESCRIPTION
## Summary
- add .gitignore with common rules for Shopify themes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844a6d232908322b7be4638ee338717